### PR TITLE
Typo fixes

### DIFF
--- a/cpu-memory/README.md
+++ b/cpu-memory/README.md
@@ -11,7 +11,7 @@ Most of the ML workload compute happens on GPUs, but typically there should be a
 - Possible parameter and optimizer state offloading when using frameworks like  [Deepspeed](https://www.deepspeed.ai/tutorials/zero-offload/). In which case quite a lot of CPU memory might be needed.
 - Activations calculated in the `forward` pass, and which need to be available for the `backward` path can also be offloaded to CPU, rather than discarded and then recomputed during the backward pass to save the unnecessary overhead
 - `DataLoader` is usually one of the main users of CPU memory and at times it may consume very large amounts of memory. Typically there are at least 2x 8 DL workers running on each node, so you need enough memory to support at least 16 processes each holding some data. For example, in the case of streaming data from the cloud, if the data shards are large, these processes could easily eat up hundreds of GBs of CPU memory.
-- The software itself and its dependant libraries uses a bit of CPU memory, but this amount is usually negligible.
+- The software itself and its dependent libraries uses a bit of CPU memory, but this amount is usually negligible.
 
 ## Things to know
 

--- a/debug/torch-distributed-hanging-solutions.md
+++ b/debug/torch-distributed-hanging-solutions.md
@@ -24,7 +24,7 @@ py-spy dump -n -p PID
 and it will tell you where the process hangs (very often it's a nccl collective function or a `barrier`).
 
 - `PID` is the process id of the hanging python process.
-- `-n` is useful if you want to see strack traces from python extensions written in C, C++, etc., as the program may hang in one of the extensions
+- `-n` is useful if you want to see stack traces from python extensions written in C, C++, etc., as the program may hang in one of the extensions
 - you may need to add `sudo` before the command - for more details see [this note](https://github.com/benfred/py-spy#when-do-you-need-to-run-as-sudo).
 
 If you have no `sudo` access your sysadmin might be able to perform this for you:

--- a/debug/underflow_overflow.py
+++ b/debug/underflow_overflow.py
@@ -80,7 +80,7 @@ class DebugUnderflowOverflow:
     You can see here, that `T5DenseGatedGeluDense.forward` resulted in output activations, whose absolute max value was
     around 62.7K, which is very close to fp16's top limit of 64K. In the next frame we have `Dropout` which
     renormalizes the weights, after it zeroed some of the elements, which pushes the absolute max value to more than
-    64K, and we get an overlow.
+    64K, and we get an overflow.
 
     As you can see it's the previous frames that we need to look into when the numbers start going into very large for
     fp16 numbers.

--- a/fault-tolerance/README.md
+++ b/fault-tolerance/README.md
@@ -256,7 +256,7 @@ for batch in iterator:
     train_step(batch)
 ```
 
-footnote: don't do this unless you really have to, since caching makes things faster. Ideally figure out the fragmentation issue instead. For example, look up `max_split_size_mb` in the doc for [`PYTORCH_CUDA_ALLOC_CONF`](https://pytorch.org/docs/stable/notes/cuda.html#environment-variables) as it controls how memory is allocated. Some frameworks like [Deepspeed](https://github.com/microsoft/DeepSpeed) solve this by pre-allocating tensors at start time and then re-use them again and again preventing the issue of fragmentation altogether.
+footnote: don't do this unless you really have to, since caching makes things faster. Ideally figure out the fragmentation issue instead. For example, look up `max_split_size_mb` in the doc for [`PYTORCH_CUDA_ALLOC_CONF`](https://pytorch.org/docs/stable/notes/cuda.html#environment-variables) as it controls how memory is allocated. Some frameworks like [Deepspeed](https://github.com/microsoft/DeepSpeed) solve this by pre-allocating tensors at start time and then reuse them again and again preventing the issue of fragmentation altogether.
 
 footnote: this simplified example would work for a single node. For multiple nodes you'd need to gather the stats from all participating nodes and find the one that has the least amount of memory left and act upon that.
 
@@ -267,7 +267,7 @@ Earlier you have seen how the training can be gracefully stopped with a [kill sw
 
 On HPC clusters SLURM jobs have a maximum runtime. A typical one is 20 hours. This is because on HPCs resources are shared between multiple users/groups and so each is given a time slice to do compute and then the job is forcefully stopped, so that other jobs could use the shared resources.
 
-footnote: this also means that you can't plan how long the training will take unless your jobs run with the highest priority on the cluster. If your priority is not the highest it's not uncommmon to have to wait for hours and sometimes days before your job resumes.
+footnote: this also means that you can't plan how long the training will take unless your jobs run with the highest priority on the cluster. If your priority is not the highest it's not uncommon to have to wait for hours and sometimes days before your job resumes.
 
 One could, of course, let the job killed and hope that not many cycles were spent since [the last checkpoint was saved](#frequent-checkpoint-saving) and then let the job resume from this checkpoint, but that's quite wasteful and best avoided.
 

--- a/io/README.md
+++ b/io/README.md
@@ -16,7 +16,7 @@ Incoming suggestions from Ross Wightman to integrate:
 
 - I'd try to separate volumes by workload, so keep the 'lots of small files', high churn like environments, code separate from bulk storage like datasets, checkpoints. Possibly even split those too since datasets are largely static and checkpoints are being rotated all the time
 
-- When datasets are on network storage, just like bucket storage, they should consist of large files AND be read as large files (sequentially in large chunks, not mmaped!). Avoid seeking within datasets
+- When datasets are on network storage, just like bucket storage, they should consist of large files AND be read as large files (sequentially in large chunks, not mmapped!). Avoid seeking within datasets
 
 - Setups like HF datasets can be deceiving, might look like one big file, but often being mmap'd and the IO read pattern is nuts, like 3-4x more iops than if you'd read them as individual files.
   Mmap loading can be turned off, but if that's the case, for a lot of datasets you move a problem into the DataLoader processes, requiring reading too much data into memory at once. Better awareness of tradeoffs for different use cases, and especially using Iterable streaming when appropriate.

--- a/multi-node/emulate-multi-node.md
+++ b/multi-node/emulate-multi-node.md
@@ -229,6 +229,6 @@ The following is an orthogonal need to the one discussed in this document, but i
 With NVIDIA A100 you can use [MIG](https://www.nvidia.com/en-us/technologies/multi-instance-gpu/) to emulate up to 7 instances of GPUs on just one real GPU, but alas you can't use those instances for anything but standalone use - e.g. you can't do DDP or any NCCL comms over those GPUs. I hoped I could use my A100 to emulate 7 instances and add one more real GPU and to have 8x GPUs to do development with - but nope it doesn't work. Asking NVIDIA engineers about it, there are no plans to have this use-case supported.
 
 
-# Acknowlegements
+# Acknowledgements
 
 Many thanks to [Jeff Rasley](https://github.com/jeffra/) for helping me to set this up.

--- a/network/README.md
+++ b/network/README.md
@@ -172,7 +172,7 @@ footnote: It's a ~3x [989 TFLOPS on H100](https://www.nvidia.com/en-us/data-cent
 
 So continuing this train of thought it means that the setup will have about 156TFLOPS - and so it'll take 0.42 secs to process a single iteration (2x `forward` and 2x `backward` compute) if we ignore the overhead of the DataLoader (which we hope is close to instant).
 
-Earlier we said that a typical A100 node has an intra-node NVLink connectin of 600GBps, and thus we said that to send 16GB of grads will take `16/600` = 0.027 secs.
+Earlier we said that a typical A100 node has an intra-node NVLink connection of 600GBps, and thus we said that to send 16GB of grads will take `16/600` = 0.027 secs.
 
 And we measured our compute to be 0.42 secs, so here are we good as `0.027 < 0.42` so the comms will be faster than compute and not be a bottleneck.
 

--- a/slurm/undrain-good-nodes.sh
+++ b/slurm/undrain-good-nodes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# When nodes get auto placed in drain because SLURM fails to wait till all last job's processes are killed and it just takes longer for them to finishe, this script automatically checks if all processes tied to the gpu have been killed and if this is so it'll undrain those nodes
+# When nodes get auto placed in drain because SLURM fails to wait till all last job's processes are killed and it just takes longer for them to finish, this script automatically checks if all processes tied to the gpu have been killed and if this is so it'll undrain those nodes
 
 # get the nodes that were put to `drain` because the job was too slow to exit
 nodes=( $(sinfo -R | grep "Kill task failed" | perl -lne '/(node-.*[\d\]]+)/ && print $1' | xargs -n1 scontrol show hostnames) )
@@ -20,7 +20,7 @@ for n in "${nodes[@]}"; do
         clean=0
         # if there are processes running still try to kill them again and recheck if it was successful
 
-        # kill any processes tieing up the gpus
+        # kill any processes tying up the gpus
         PDSH_RCMD_TYPE=ssh pdsh -w $n "nvidia-smi --query-compute-apps=pid --format=csv,noheader | sort | uniq | xargs -n1 sudo kill -9"
 
         echo "sleeping for 3 secs to let the processes exit"

--- a/slurm/users.md
+++ b/slurm/users.md
@@ -122,7 +122,7 @@ Note that depending on your application there can be quite a performance differe
 On some setups like AWS the network's performance degrades dramatically when `--hint=nomultithread` is used!
 
 
-## Re-use allocation
+## Reuse allocation
 
 e.g. when wanting to run various jobs on identical node allocation.
 


### PR DESCRIPTION
Found by running [codespell](https://github.com/codespell-project/codespell) on the repository:

```bash
$ codespell .                                                          
./fault-tolerance/README.md:259: re-use ==> reuse
./fault-tolerance/README.md:270: uncommmon ==> uncommon
./slurm/undrain-good-nodes.sh:3: finishe ==> finished, finish
./slurm/undrain-good-nodes.sh:23: tieing ==> tying
./slurm/users.md:125: Re-use ==> Reuse
./network/README.md:175: connectin ==> connecting, connection
./multi-node/emulate-multi-node.md:232: Acknowlegements ==> Acknowledgements
./io/README.md:19: mmaped ==> mapped
./debug/torch-distributed-hanging-solutions.md:27: strack ==> stack, track
./debug/underflow_overflow.py:83: overlow ==> overflow
./cpu-memory/README.md:14: dependant ==> dependent
```

Not entirely sure of `mmaped`  -> `mmapped`.