### PR TITLE
Add num_processes and num_machines to accelerate launcher

### DIFF
--- a/orchestration/slurm/launchers/accelerate-launcher.slurm
+++ b/orchestration/slurm/launchers/accelerate-launcher.slurm
@@ -33,7 +33,7 @@ ACCELERATE_CONFIG_FILE=accelerate.yaml
 # EDIT if it's not 8-gpus per node
 GPUS_PER_NODE=8
 NNODES=$SLURM_NNODES
-NUM_PROCESSES=$(expr $NNODES \* $GPUS_PER_NODE)
+NUM_PROCESSES=$(($NNODES * $GPUS_PER_NODE))
 
 # define the node 0 hostname:port
 MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)

--- a/orchestration/slurm/launchers/accelerate-launcher.slurm
+++ b/orchestration/slurm/launchers/accelerate-launcher.slurm
@@ -33,6 +33,7 @@ ACCELERATE_CONFIG_FILE=accelerate.yaml
 # EDIT if it's not 8-gpus per node
 GPUS_PER_NODE=8
 NNODES=$SLURM_NNODES
+NUM_PROCESSES=$(expr $NNODES \* $GPUS_PER_NODE)
 
 # define the node 0 hostname:port
 MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
@@ -45,6 +46,8 @@ MASTER_PORT=6000
 LAUNCHER="python -u -m accelerate.commands.launch \
     --rdzv_conf "rdzv_backend=c10d,rdzv_endpoint=$MASTER_ADDR:$MASTER_PORT" \
     --config_file $ACCELERATE_CONFIG_FILE \
+    --num_processes $NUM_PROCESSES \
+    --num_machines $NNODES \
     --main_process_ip $MASTER_ADDR \
     --main_process_port $MASTER_PORT \
     --machine_rank \$SLURM_PROCID \


### PR DESCRIPTION
## Description
This pull request improves the multi-node training configuration for the accelerate launcher by adding the `num_processes` and `num_machines` arguments.

## Changes
- Calculate the total number of processes (`NUM_PROCESSES`) based on the number of nodes (`NNODES`) and GPUs per node (`GPUS_PER_NODE`).
- Pass the `--num_processes` argument to the accelerate launcher with the calculated `NUM_PROCESSES` value.
- Pass the `--num_machines` argument to the accelerate launcher with the `NNODES` value.


By providing the total number of processes and the number of machines to the accelerate launcher, we enable multi-node training configuration. 

## Checklist
- [x] Tested the changes in a multi-node environment

Please review and provide feedback. Let me know if you have any questions or concerns.