### PR TITLE
Update GH200 MAMF

### DIFF
--- a/compute/accelerator/README.md
+++ b/compute/accelerator/README.md
@@ -206,6 +206,7 @@ The following measurements are for `matmul` with BF16 inputs (no sparsity) TFLOP
 | Accelerator      | MAMF | Theory | Efficiency |      Best Shape | Notes      |
 | :--------------- | ----: | -----: | ---------: | :-------------- | ---------: |
 | NVIDIA A100 SXM  | 267.9 |    312 |      85.9% | 6912x16384x2048 | CUDA-12.1  |
+| NVIDIA GH200 SXM | 821.0 |    989 |      83.0% | 11264x19712x1536| CUDA-12.5  |
 | NVIDIA A100 PCIe | 256.4 |    312 |      82.2% |  2304x5120x1536 | CUDA-12.1  |
 | NVIDIA H100 SXM  | 792.1 |    989 |      80.1% | 6144x17920x2816 | CUDA-12.1  |
 | AMD MI300X       | 758.3 |   1300 |      58.3% | 4352x13568x3840 | ROCm-6.2   |

--- a/compute/accelerator/benchmarks/mamf-finder.py
+++ b/compute/accelerator/benchmarks/mamf-finder.py
@@ -270,9 +270,9 @@ if __name__ == '__main__':
             for K in k:
                 num_shapes += 1
                 tflops = benchmark_mm(M, N, K, dtype, device, args.num_iterations, args.num_warmup_iterations)
+                cur_config = f"{M}x{N}x{K}"
                 if tflops > best_tflops:
                     best_tflops = tflops
                     best_config = f"{M}x{N}x{K} (MxNxK)"
-                    cur_config = f"{M}x{N}x{K}"
                 print(f"{num_shapes:>6} | {tflops:6.1f} TFLOPS @ {cur_config:<20} | best: {best_tflops:6.1f} TFLOPS @ {best_config}", end="\r")
     finish()


### PR DESCRIPTION
Benchmark started on 2024-08-09 04:29:14

** Command line:
/usr/bin/python ./mamf-finder.py --m_range 0 20480 256 --n_range 0 20480 256 --k_range 0 20480 256 --output_file=2024-08-09-04:29:13.txt

** Dtype: torch.bfloat16

** Platform/Device info:
Linux \*.\*.ucl.ac.uk 5.14.0-362.18.1.el9_3.aarch64+64k #1 SMP PREEMPT_DYNAMIC Wed Jan 3 17:45:35 EST 2024 aarch64 aarch64
_CudaDeviceProperties(name='NVIDIA GH200 480GB', major=9, minor=0, total_memory=96768MB, multi_processor_count=132)

** Critical software versions:
torch=2.4.0a0+f70bd71a48.nv24.06
cuda=12.5


The best outcome was 821.0TFLOPS @ 11264x19712x1536 (MxNxK) (tried 493039 shapes)
Elapsed time: 2 days, 14:42:00
