### PR TITLE
Simplify fp8e4m3 benchmark

### DIFF
--- a/compute/accelerator/README.md
+++ b/compute/accelerator/README.md
@@ -270,7 +270,7 @@ The following measurements are for `matmul` with BF16 and FP8 inputs (no sparsit
 | NVIDIA GH200 SXM |  828.6 |    989 |      83.6% |   1024x15360x4096 | 2.6.0+cu126     | 900W 141GB HBM3e version           |
 | NVIDIA A100 PCIe |  252.9 |    312 |      81.1% |    2048x5120x6144 | 2.5.1+cu124     |                                    |
 | NVIDIA H100 SXM  |  794.5 |    989 |      80.3% |   2048x2048x13312 | 2.7.0+cu126     |                                    |
-| AMD MI300X       |  659.7 |   1300 |      50.7% |  10240x15360x8192 | 2.5.1+6.3.42131 | PYTORCH_TUNABLEOP_ENABLED=1        |
+| AMD MI300X       |  668.4 |   1300 |      51.4% |  10240x15360x8192 | 2.5.1+6.3.42131 | PYTORCH_TUNABLEOP_ENABLED=1        |
 | AMD MI325X       |  784.9 |   1300 |      60.4% |  13312x10240x8192 | 2.6.0+6.2.4     | 1000W, PYTORCH_TUNABLEOP_ENABLED=1 |
 | Intel Gaudi 2    |        |    432 |            |                   |                 |                                    |
 | Intel Gaudi 3    |        |   1835 |            |                   |                 |                                    |

--- a/compute/accelerator/benchmarks/mamf-finder.py
+++ b/compute/accelerator/benchmarks/mamf-finder.py
@@ -232,13 +232,14 @@ def benchmark_mm(m, n, k, dtype, device, num_iterations, num_warmup_iterations):
             
         A = torch.randn(m, k, dtype=torch.float32, device=device).contiguous()
         B = torch.randn(n, k, dtype=torch.float32, device=device).contiguous().t()
+        scale = torch.tensor([1.0]).to(device)
         A = A.to(torch.float8_e4m3fn)
         B = B.to(torch.float8_e4m3fn)
         
         # Simplified call for PyTorch 2.5+
         @time_it(total_iterations)
         def time_iterations():
-            C = torch._scaled_mm(A, B)
+            C = torch._scaled_mm(A, B, scale, scale)
 
     else:
         A = torch.randn(m, k, dtype=dtype, device=device).contiguous()

--- a/compute/accelerator/benchmarks/mamf-finder.py
+++ b/compute/accelerator/benchmarks/mamf-finder.py
@@ -240,23 +240,19 @@ def benchmark_mm(m, n, k, dtype, device, num_iterations, num_warmup_iterations):
                 @time_it(total_iterations)
                 def time_iterations():
                     result, _ = torch._scaled_mm(A, B)
-                    C.copy_(result)
             else:
                 @time_it(total_iterations)
                 def time_iterations():
                     result = torch._scaled_mm(A, B)
-                    C.copy_(result)
         except:
             if returns_tuple:
                 @time_it(total_iterations)
                 def time_iterations():
                     result, _ = torch._scaled_mm(A, B, scale, scale)
-                    C.copy_(result)
             else:
                 @time_it(total_iterations)
                 def time_iterations():
                     result = torch._scaled_mm(A, B, scale, scale)
-                    C.copy_(result)
 
     else:
         A = torch.randn(m, k, dtype=dtype, device=device).contiguous()


### PR DESCRIPTION
To solve the bug:

```shell
Traceback (most recent call last):
  File "/home/xingzai/mamf-finder.py", line 353, in <module>
    _ = benchmark_mm(m[0], n[0], k[0], dtype, device, args.num_iterations, args.num_warmup_iterations)
  File "/home/xingzai/mamf-finder.py", line 255, in benchmark_mm
    times = time_iterations()[num_warmup_iterations:]
  File "/home/xingzai/mamf-finder.py", line 216, in func_wrapper
    C.copy_(C_rand)  # re-randomize the target matrix
AttributeError: 'tuple' object has no attribute 'copy_'
```

After remove the code, I can run normaly now :

![图片](https://github.com/user-attachments/assets/a41405f8-0b0f-4e38-8ef2-b8e0db313b44)
