### PR TITLE
match nccl-test display

### DIFF
--- a/network/benchmarks/all_reduce_bench.py
+++ b/network/benchmarks/all_reduce_bench.py
@@ -190,7 +190,7 @@ def run(local_rank):
         print(f"| payload |    busbw   |    algbw   |")
         print(f"| ------: | ---------: | ---------: |")
         for size in busbw.keys():
-            print(f"| {fmt_bytes(size):>7} | {busbw[size]/2**30:6.2f}GBps | {algbw[size]/2**30:6.2f}GBps |")
+            print(f"| {fmt_bytes(size):>7} | {busbw[size]/10**9:6.2f}GBps | {algbw[size]/10**9:6.2f}GBps |")
 
         print(f"\n*** Plotting results into {plot_path}\n")
         busbw_GBps = [x/2**30 for x in busbw.values()]


### PR DESCRIPTION
When displaying results (calculated in bytes by the script), make sure that values displayed in GBps are calculated with a base-10 denominator, instead of base-2. This matches the way nccl-test displays results, to avoid confusion when comparing results between nccl-test and this benchmark.

In initial testing, results of nccl-test and this benchmark are roughly the same on the same cluster:
![image](https://github.com/user-attachments/assets/640a87da-077d-4c4c-b994-57921e20dcdc)
