### PR TITLE
feat: all reduce bench slurm pyxis

### DIFF
--- a/network/benchmarks/README.md
+++ b/network/benchmarks/README.md
@@ -79,9 +79,15 @@ Here is a simple all-reduce benchmark that you can use to quickly measure the th
 
 [all_reduce_bench.py](all_reduce_bench.py)
 
+On CSPs that have enabled [SLURM Pyxis Container Plugin](https://github.com/NVIDIA/pyxis), such as CoreWeave, Crusoe, AWS, Oracle, Azure, GCP, etc, `all_reduce_bench.py` can be easily ran & reproduced via the following command:
+```bash
+sbatch -n <num_of_nodes> ./all_reduce_bench_pyxis.sbatch
+```
+
 Usually benchmarking at least 4 nodes is recommended, but, of course, if you already have access to all the nodes you will be using during the training, benchmark using all of the nodes.
 
-To run it on 4 nodes:
+
+If do not you have access to an pyxis SLURM environment, to run it on 4 nodes:
 
 ```
 GPUS_PER_NODE=8

--- a/network/benchmarks/README.md
+++ b/network/benchmarks/README.md
@@ -87,7 +87,7 @@ sbatch -n <num_of_nodes> ./all_reduce_bench_pyxis.sbatch
 Usually benchmarking at least 4 nodes is recommended, but, of course, if you already have access to all the nodes you will be using during the training, benchmark using all of the nodes.
 
 
-If do not you have access to an pyxis SLURM environment, to run it on 4 nodes:
+If you do not have access to a pyxis SLURM environment, to run it on 4 nodes:
 
 ```
 GPUS_PER_NODE=8

--- a/network/benchmarks/all_reduce_bench_pyxis.sbatch
+++ b/network/benchmarks/all_reduce_bench_pyxis.sbatch
@@ -7,7 +7,7 @@
 
 # Set up environment variables for torchrun
 GPUS_PER_NODE=8
-NNODES=2
+NNODES=$SLURM_NNODES
 MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 MASTER_PORT=6000
 

--- a/network/benchmarks/all_reduce_bench_pyxis.sbatch
+++ b/network/benchmarks/all_reduce_bench_pyxis.sbatch
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --job-name=all_reduce_bench_pyxis
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:8
+#SBATCH --time=01:00:00
+
+# Set up environment variables for torchrun
+GPUS_PER_NODE=8
+NNODES=2
+MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
+MASTER_PORT=6000
+
+srun --container-image=nvcr.io#nvidia/pytorch:25.02-py3 \
+     --container-mounts=$PWD:/workspace \
+     python -u -m torch.distributed.run \
+         --nproc_per_node $GPUS_PER_NODE \
+         --nnodes $NNODES \
+         --rdzv_endpoint ${MASTER_ADDR}:${MASTER_PORT} \
+         --rdzv_backend c10d \
+         --max_restarts 0 \
+         --role `hostname -s`':' \
+         --tee 3 \
+         all_reduce_bench.py


### PR DESCRIPTION
[SLURM Pyxis Container Plugin](https://github.com/NVIDIA/pyxis) allows for easy reproducible scripts where the environment is containerized as such the benchmark harness script does not rely on any host machine dependencies besides the standard SLURM, `pyxis SLURM plugin` and `nvidia-drivers`.

 [SLURM Pyxis Container Plugin](https://github.com/NVIDIA/pyxis) is widely used across many companies and increasingly gaining adoption.


On CSPs that have enabled [SLURM Pyxis Container Plugin](https://github.com/NVIDIA/pyxis), such as CoreWeave, Crusoe,  Oracle, Azure, etc, `all_reduce_bench.py` can be easily ran & reproduced via the following command:
```bash
sbatch -n <num_of_nodes> ./all_reduce_bench_pyxis.sbatch
```

Note that on AWS & GCP, this launcher will work too once you swapped `nvcr.io#nvidia/pytorch:25.02-py3` and AWS/GCP specific container image that has all of the env vars and AWS EFA or GCP `GPUDirect-TCP` or `GPUDirect-TCPXO` aka `FastTrak` or `gIB` nccl net plugin included


## Testing
I did some quick smoke tests to make sure this script works properly on two HGX H100 700W SXM nodes (16 total GPUs) with 400G InfiniBand NDR connected between them at 1 hop distance.  

![image](https://github.com/user-attachments/assets/5c6e3f0f-878d-4765-99cd-1dfe9ffe59ab)

![image](https://github.com/user-attachments/assets/b2d35402-0d9c-4a15-b3d8-5965e1cf5ad1)

