### PR TITLE
benchmark: add support for Intel xpu devices

### DIFF
--- a/compute/accelerator/benchmarks/README.md
+++ b/compute/accelerator/benchmarks/README.md
@@ -37,6 +37,8 @@ export PYTORCH_TUNABLEOP_ENABLED=1
 ```
 This will make the first iteration very slow, while it's searching for the best GEMM algorithm in the BLAS libraries for each `matmul` shape it encounters, but subsequent operations are likely to be significantly faster than the baseline. See [Accelerating models on ROCm using PyTorch TunableOp](https://rocm.blogs.amd.com/artificial-intelligence/pytorch-tunableop/README.html) (requires `torch>=2.3`) [doc](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cuda/tunable/README.md).
 
+**Intel dGPUs (A770, A750, B580, etc.)**
+- Follow Intel Extension for Pytorch [installation steps](https://pytorch-extension.intel.com/installation?platform=gpu)
 
 ### Examples of usage
 

--- a/compute/accelerator/benchmarks/mamf-finder.py
+++ b/compute/accelerator/benchmarks/mamf-finder.py
@@ -152,7 +152,7 @@ def get_accelerator_arch():
     if torch.xpu.is_available():
         return XPUArch()
 
-    raise ValueError("Currently only cuda, rocm and hpu are supported")
+    raise ValueError("Currently only cuda, rocm, hpu and xpu are supported")
 
 arch = get_accelerator_arch()
 

--- a/compute/accelerator/benchmarks/mamf-finder.py
+++ b/compute/accelerator/benchmarks/mamf-finder.py
@@ -114,6 +114,28 @@ class HPUArch(Arch):
     def synchronize(self):
         ht.hpu.synchronize()
 
+class XPUArch(Arch):
+    """ Intel dGPUs (like ARC A770) """
+    def __init__(self):
+        self.arch = "xpu"
+
+    def device(self):
+        return torch.device('xpu')
+
+    def name(self):
+        return self.arch
+
+    def device_info(self):
+        return torch.xpu.get_device_properties(device)
+
+    def compute_info(self):
+        return f"xpu={torch.version.xpu}"
+
+    def event(self, enable_timing=True):
+        return torch.xpu.Event(enable_timing)
+
+    def synchronize(self):
+        torch.xpu.synchronize()
 
 def get_accelerator_arch():
     """
@@ -126,6 +148,9 @@ def get_accelerator_arch():
     # hpu
     if has_hpu:
         return HPUArch()
+
+    if torch.xpu.is_available():
+        return XPUArch()
 
     raise ValueError("Currently only cuda, rocm and hpu are supported")
 


### PR DESCRIPTION
Got the benchmark working with XPUs and validated on Intel Arc A770.

Output from a run:
```
Benchmark started on 2025-06-02 20:57:20

** Command line:
python3 ml-engineering/compute/accelerator/benchmarks/mamf-finder.py --m 4096 --n 4096 --k_range 256 4096 256

** Dtype: torch.bfloat16

** Platform/Device info:
Linux b650 6.15.0-rc7 #1 SMP PREEMPT_DYNAMIC Sun, 25 May 2025 15:25:14 +0000 x86_64 
_XpuDeviceProperties(name='Intel(R) Arc(TM) A770 Graphics', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.33578', total_memory=15473MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=32, max_work_group_size=1024, max_num_sub_groups=128, sub_group_sizes=[8 16 32], has_fp16=1, has_fp64=0, has_atomic64=1)

** Critical software versions:
torch=2.7.0+xpu
xpu=20250004

** Additional notes:
benchmark version: 2


--------------------------------------------------------------------------------


Warming up the accelerator for 30 secs ... accelerator warmup finished

Tried  15 shapes => the best outcomes were:
mean:   91.0 TFLOPS @ 4096x4096x2048 (MxNxK)
median: 91.6 TFLOPS @ 4096x4096x2048 (MxNxK)
max:    92.9 TFLOPS @ 4096x4096x2048 (MxNxK)

geomean: 74.8 TFLOPS for 15 shapes in range: m=[4096] | n=[4096] | k=[256, 4096, 256]

Legend: TFLOPS = 10**12 FLOPS
Elapsed time: 0:00:34

```