### PR TITLE
fix typos

### DIFF
--- a/compute/accelerator/nvidia/debug.md
+++ b/compute/accelerator/nvidia/debug.md
@@ -374,7 +374,7 @@ Cloud providers usually have a mechanism of reporting bad nodes. Therefore other
 
 ## How to get the real GPU utilization metrics
 
-As explained [here](https://arthurchiao.art/blog/understanding-gpu-performance/) the `Volatile GPU-Util` column in the `nvidia-smi` output isn't really telling you the GPU Utilization. What it's telling you is the percentage of time during which one or more kernels were executing on the GPU. It's not telling you whether a single SM is being used or all of them. So even if you run a tiny `matmul` all the time, you may get a a very high gpu util, while most of the GPU isn't doing anything.
+As explained [here](https://arthurchiao.art/blog/understanding-gpu-performance/) the `GPU-Util` column in the `nvidia-smi` output isn't really telling you the GPU Utilization. What it's telling you is the percentage of time during which one or more kernels were executing on the GPU. It's not telling you whether a single SM is being used or all of them. So even if you run a tiny `matmul` all the time, you may get a very high gpu util, while most of the GPU isn't doing anything.
 
 footnote: I have seen GPU util column showing 100% on all gpus when one GPU would stop responding and then whole machinery was blocked waiting for that gpu to respond. Which is how I discovered that it couldn't be showing the real GPU utilization in the first place.
 


### PR DESCRIPTION
I think columns of nvidia-smi result is not "Volatile GPU-Util" and "Uncorr. ECC", but "GPU-Util" and "Volatile Uncorr. ECC".