### PR TITLE
fix: use out kwarg of _scaled_mm

### DIFF
--- a/compute/accelerator/benchmarks/mamf-finder.py
+++ b/compute/accelerator/benchmarks/mamf-finder.py
@@ -270,6 +270,7 @@ def benchmark_mm(m, n, k, dtype, device, num_iterations, num_warmup_iterations):
         # Simplified call for PyTorch 2.5+
         @time_it(total_iterations)
         def time_iterations():
+            # must not move `out=C` as `C = ...` as Gaudi needs it this way to work
             torch._scaled_mm(A, B, scale, scale, out=C)
 
     else:

--- a/compute/accelerator/benchmarks/mamf-finder.py
+++ b/compute/accelerator/benchmarks/mamf-finder.py
@@ -270,7 +270,7 @@ def benchmark_mm(m, n, k, dtype, device, num_iterations, num_warmup_iterations):
         # Simplified call for PyTorch 2.5+
         @time_it(total_iterations)
         def time_iterations():
-            C = torch._scaled_mm(A, B, scale, scale)
+            torch._scaled_mm(A, B, scale, scale, out=C)
 
     else:
         A = torch.randn(m, k, dtype=dtype, device=device).contiguous()


### PR DESCRIPTION
`C = torch._scaled_mm(A, B, scale, scale)` never triggers the actual matrix multiplication in Gaudi’s lazy execution mode, since operations are deferred until required (e.g., when the output is evaluated, or when an H↔D sync is needed). To ensure the matrix multiplication is executed properly, the code should be written as `torch._scaled_mm(A, B, scale, scale, out=C)`. This change might affect some of the previous benchmarks, but it also aligns with how other dtypes are measured.

This PR addresses the FP8 benchmark issue described in https://github.com/stas00/ml-engineering/issues/115