### PR TITLE
docs: add Strix Halo inference case study

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -740,3 +740,4 @@ Besides general purpose accelerators some vendors have been working special ASIC
 ## Resources
 
 - [A Survey on Efficient Inference for Large Language Models (2024)](https://arxiv.org/abs/2404.14294)
+- [AMD Strix Halo Local LLM Guide](https://github.com/hogeheer499-commits/strix-halo-guide) - a reproducible consumer unified-memory inference case study covering Ubuntu, llama.cpp, Ollama, Vulkan/RADV, ROCm, model and quantization choices, benchmark methodology, raw evidence, and failed routes.


### PR DESCRIPTION
## What changed

Added the AMD Strix Halo Local LLM Guide to the inference chapter's existing Resources section.

## Why

The current section links an inference survey but no practical consumer unified-memory case study. This guide documents a reproducible Ryzen AI MAX+ 395 path across Ubuntu, llama.cpp, Ollama, Vulkan/RADV, ROCm, model and quantization selection, benchmark methodology, raw evidence, and failed routes.

This is a single resource link and does not change the chapter's framework guidance.

## Checks

- `git diff --check`
- Verified the target URL returns HTTP 200
